### PR TITLE
Lower minimum version in podspec

### DIFF
--- a/RNFS.podspec
+++ b/RNFS.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.2'
-  s.macos.deployment_target = '10.14'
+  s.macos.deployment_target = '10.13'
 
   s.source          = { :git => "https://github.com/eldh/react-native-fs", :tag => "v#{s.version}" }
   s.source_files    = '*.{h,m}'


### PR DESCRIPTION
Hi, I found your repo based on this issue. https://github.com/itinance/react-native-fs/issues/887

I installed it in my project but I got an error when running `pod install`. 

>Auto-linking React Native module for target `ExpansionOrganizer-macOS`: RNFS
Auto-linking React Native module for target `ExpansionOrganizer-iOS`: RNFS
Analyzing dependencies
[!] CocoaPods could not find compatible versions for pod "RNFS":
  In Podfile:
    RNFS (from `../node_modules/react-native-fs`)
Specs satisfying the `RNFS (from `../node_modules/react-native-fs`)` dependency were found, but they required a higher minimum deployment target.

It looks like the main Microsoft repository has [moved the minimum version down from 10.14 to 10.13](https://github.com/microsoft/react-native-macos/pull/555) since this repo has been created. The `npm run start:macos` command has a default target of 10.13 now which fails the requirement of 10.14 in this repository.

I think the change I've included is the right fix for this problem -- it fixed my issue anyway.